### PR TITLE
Feat/#6: Button 컴포넌트 구현

### DIFF
--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -1,0 +1,38 @@
+import styled from '@emotion/styled';
+import { ReactNode } from 'react';
+
+interface ButtonProps {
+  children?: ReactNode;
+  onClick?: () => void;
+  disabled?: boolean;
+}
+
+const Button = ({ children, disabled = false, ...props }: ButtonProps) => {
+  return (
+    <StyledButton type="button" disabled={disabled} {...props}>
+      {children}
+    </StyledButton>
+  );
+};
+
+export default Button;
+
+const StyledButton = styled.button`
+  cursor: pointer;
+
+  width: 100%;
+  height: 50px;
+  margin: 4px 0;
+
+  border-radius: 8px;
+
+  background-color: #71bc5c;
+  color: #ffffff;
+  font-weight: bold;
+
+  &:disabled {
+    background-color: #e7e7e7;
+    color: #868686;
+    cursor: auto;
+  }
+`;

--- a/src/styles/Global/index.tsx
+++ b/src/styles/Global/index.tsx
@@ -125,6 +125,9 @@ const resetCss = css`
     border-collapse: collapse;
     border-spacing: 0;
   }
+  button {
+    border: none;
+  }
 `;
 
 const Global = () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "jsxImportSource": "@emotion/react"
   },
   "include": ["src"],
   "extends": "./tsconfig.path.json",


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->

- Closes: #6 

## 💫 설명

<!--

- 현재 Pr 설명

-->

- Button 컴포넌트 구현했어요. 일단은 디자인에 있는 컴포넌트만 고려했습니다.
  - `width: 100%`로 줘서 아마 레이아웃 잡으면 그거에 맞게 들어갈거에요.
  - disabled 속성 따로 안주면 enabled된 상태가 default에요.

## 📷 스크린샷 (Optional)

### 예시
```ts
const 예시 = () => {
  const [count, setCount] = useState(0);

  return (
    <>
      {count}
      <div
        css={css`
          display: flex;
          flex-direction: row;
        `}
      >
        <Button onClick={() => setCount(count + 1)}>+1</Button>
        <Button onClick={() => setCount(count - 1)}>-1</Button>
      </div>
      <Button disabled={count < 3}>hi</Button>
    </>
  );
};
```

https://user-images.githubusercontent.com/65100540/226532643-1c1963bf-f3f4-4e23-b404-7e1080ec1f63.mov

