### PR TITLE
Config/#47: contexts 폴더 절대경로로 설정

### DIFF
--- a/tsconfig.path.json
+++ b/tsconfig.path.json
@@ -5,6 +5,7 @@
       "@type/*": ["./src/@types/*"],
       "@components/*": ["./src/components/*"],
       "@constants/*": ["./src/constants/*"],
+      "@contexts/*": ["./src/contexts/*"],
       "@styles/*": ["./src/styles/*"],
       "@utils/*": ["./src/utils/*"],
       "@hooks/*": ["./src/hooks/*"],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,10 @@ export default defineConfig({
         replacement: resolve(__dirname, './src/constants'),
       },
       {
+        find: '@contexts',
+        replacement: resolve(__dirname, './src/contexts'),
+      },
+      {
         find: '@styles',
         replacement: resolve(__dirname, './src/styles'),
       },


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->
* Closes : #47 
* contexts 폴더 절대경로로 설정 했어요~
## 💫 설명

<!--

- 현재 Pr 설명

-->

```typescript
{
        find: '@contexts',
        replacement: resolve(__dirname, './src/contexts'),
},
```

## 📷 스크린샷 (Optional)
