### PR TITLE
Feat/#49: 전공상태 전역으로 관리하기 위한 Context 생성

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ export default {
     '^@type/(.*)$': '<rootDir>/src/@types/$1',
     '^@components/(.*)$': '<rootDir>/src/components/$1',
     '^@constants/(.*)$': '<rootDir>/src/constants/$1',
+    '^@contexts/(.*)$': '<rootDir>/src/contexts/$1',
     '^@styles/(.*)$': '<rootDir>/src/styles/$1',
     '^@utils/(.*)$': '<rootDir>/src/utils/$1',
     '^@hooks/(.*)$': '<rootDir>/src/hooks/$1',

--- a/src/@types/major.ts
+++ b/src/@types/major.ts
@@ -1,0 +1,3 @@
+type Major = '컴퓨터공학과' | null;
+
+export default Major;

--- a/src/components/MajorProvider/index.tsx
+++ b/src/components/MajorProvider/index.tsx
@@ -1,0 +1,19 @@
+import MajorContext from '@contexts/major';
+import Major from '@type/major';
+import React, { useState } from 'react';
+
+interface MajorProviderProps {
+  children: React.ReactNode;
+}
+
+const MajorProvider = ({ children }: MajorProviderProps) => {
+  const [major, setMajor] = useState<Major>(null);
+
+  return (
+    <MajorContext.Provider value={{ major, setMajor }}>
+      {children}
+    </MajorContext.Provider>
+  );
+};
+
+export default MajorProvider;

--- a/src/contexts/major.ts
+++ b/src/contexts/major.ts
@@ -1,0 +1,11 @@
+import Major from '@type/major';
+import { createContext } from 'react';
+
+interface MajorState {
+  major: Major;
+  setMajor: React.Dispatch<React.SetStateAction<Major>>;
+}
+
+const MajorContext = createContext<MajorState | null>(null);
+
+export default MajorContext;

--- a/src/hooks/useMajor.ts
+++ b/src/hooks/useMajor.ts
@@ -1,0 +1,14 @@
+import MajorContext from '@contexts/major';
+import { useContext } from 'react';
+
+const useMajor = () => {
+  const context = useContext(MajorContext);
+
+  if (!context) {
+    throw new Error('MajorContext does not exists.');
+  }
+
+  return context;
+};
+
+export default useMajor;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import MajorProvider from '@components/MajorProvider';
 import ThemeProvider from '@styles/ThemeProvider';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
@@ -9,7 +10,9 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
       <ThemeProvider>
-        <App />
+        <MajorProvider>
+          <App />
+        </MajorProvider>
       </ThemeProvider>
     </BrowserRouter>
   </React.StrictMode>,

--- a/src/pages/MajorDecision/index.test.tsx
+++ b/src/pages/MajorDecision/index.test.tsx
@@ -7,8 +7,6 @@ import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 import MajorDecision from './index';
 
-// 훅은 오직 함수형 컴포넌트 내부에서만 사용할 수 있다.
-// const { major } = useMajor();
 const mockedUsedNavigate = jest.fn();
 
 jest.mock('react-router-dom', () => ({

--- a/src/pages/MajorDecision/index.test.tsx
+++ b/src/pages/MajorDecision/index.test.tsx
@@ -1,0 +1,55 @@
+import MajorProvider from '@components/MajorProvider';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Major from '@type/major';
+import { MemoryRouter } from 'react-router-dom';
+
+import '@testing-library/jest-dom';
+import MajorDecision from './index';
+
+// 훅은 오직 함수형 컴포넌트 내부에서만 사용할 수 있다.
+// const { major } = useMajor();
+const mockedUsedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedUsedNavigate,
+}));
+
+describe('학과선택 페이지 로직 테스트', () => {
+  it('전공 선택 버튼 클릭 후, 상태 변경 테스트', async () => {
+    render(
+      <MemoryRouter>
+        <MajorProvider>
+          <MajorDecision />
+        </MajorProvider>
+      </MemoryRouter>,
+    );
+
+    const major = screen.getByRole('note');
+    const majorButton = screen.getByText('컴퓨터공학과로 전공 선택하기');
+
+    await userEvent.click(majorButton);
+    expect(major).toHaveTextContent(('컴퓨터공학과' as Major) ?? '');
+  });
+
+  it('alert 창 메세지 확인, 메인페이지로 이동 잘 되는지 테스트', async () => {
+    const mockAlert = jest.spyOn(window, 'alert');
+
+    render(
+      <MemoryRouter initialEntries={['/major-decision']}>
+        <MajorProvider>
+          <MajorDecision />
+        </MajorProvider>
+      </MemoryRouter>,
+    );
+
+    const majorButton = screen.getByText('컴퓨터공학과로 전공 선택하기');
+
+    await userEvent.click(majorButton);
+    expect(mockAlert).toHaveBeenCalledWith('전공 선택 완료!');
+
+    mockAlert.mockClear();
+    expect(mockedUsedNavigate).toHaveBeenCalledWith('/');
+  });
+});

--- a/src/pages/MajorDecision/index.tsx
+++ b/src/pages/MajorDecision/index.tsx
@@ -1,5 +1,23 @@
+import Button from '@components/Button';
+import useMajor from '@hooks/useMajor';
+import { useNavigate } from 'react-router-dom';
+
 const MajorDecision = () => {
-  return <h1>학과 선택하기 페이지</h1>;
+  const navigate = useNavigate();
+  const { major, setMajor } = useMajor();
+
+  const onClick = () => {
+    setMajor('컴퓨터공학과');
+    alert('전공 선택 완료!');
+    navigate('/');
+  };
+
+  return (
+    <>
+      <Button onClick={onClick}>컴퓨터공학과로 전공 선택하기</Button>
+      <span role="note">{major}</span>
+    </>
+  );
 };
 
 export default MajorDecision;


### PR DESCRIPTION
## 🤠 개요

<!--

- 이슈번호
- 한줄 설명

-->

* Closes: #49 
* 전공상태를 전역으로 관리하기 위한 Context 를 생성했어요.

## 💫 설명

<!--

- 현재 Pr 설명

-->
~~이 pr 은 수정사항도 있고 일단 커밋이 많습니다..리뷰할 것도 많을 것 같아 미리 감사의 말씀을...ㅎㅎ~~

* components/`MajorProvider` 생성
  - major 전역상태 내려주는 provider 컴포넌트 따로 만들기로 슬랙에서 얘기 했어서, 따로 components 폴더에 만들었어요.

* `useMajor` 커스텀 훅 생성
  - useContext 를 통해서 내려받은 전역상태를 불러오는 로직을 커스텀 훅으로 빼는 것이 좋을 것 같아 `useMajor` 커스텀 훅을 만들었어요.

* 간단하게 전역 상태 설정하는 로직 구현
  - 학과선택페이지에서 전역상태 `컴퓨터공학과` 설정하는 로직 한번 만들어 봤어요..테스트도 해볼겸..ㅎㅎ

* `jest.config.js` 파일에 @contexts 절대경로 폴더 추가
  - jest 환경에서 @contexts 절대경로 폴더에 있는 context 들을 가져오기 위해서 설정을 추가해 줬어요.

## 📌 얻은점

* 브라우저 환경과 테스트 환경은 정말 다르다...
* 테스트 코드.. 빡세다

* 훅은 오직 함수형 컴포넌트 내부에서만 사용할 수 있다.
  - 버튼을 클릭하면, 전역상태가 제대로 설정 되는지 확인하기 위해서 테스트 함수 `it` 내부에서 `useMajor` 커스텀 훅을 호출 했었는데요..에러를 뱉더군요
  - 그래서 `span` 태그에 `note` 라는 role을 주고 이를 통해서 테스트 환경에 가져와서 상태가 제대로 변경 되는지 확인하는 로직으로 변경했습니다.

* moking..!
  - `window.alert` 의 확인 버튼을 누르면 메인페이지로 제대로 이동되는지 확인하는 테스트 코드
    -  이 확인 버튼에 `userEvent` 를 걸고 싶었는데 이 버튼을 가져올 수 있는 방법이 없다고 하네요...?
    - 그래서 `mokingAlert` 를 따로 만들어서 `mockClear()` 을 통해서 alert를 없애는 로직으로 변경 했어요
    - 가상 메모리상에서 URL 주소를 확인하려고 하니까 방법을 모르겠더라고요...그래서 메인페이지 URL 로 변경이 됐는지 테스트 하는 방법 대신에 mocking 한 `useNavigate` 함수가 '/' 이 경로로 호출이 되는지 확인 하는 방법으로 변경했어요

## 📷 스크린샷 (Optional)
